### PR TITLE
1.0 create additional test providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This extends the key/value store in several ways
   - This allows for only recording when a value changes as a logging method with the ability to retrieve the last value 
   set or the series
 
+### warning
+Keys are forced to be case-insensitive
+
 #### To Do (1.0)
 - [ ] Remove the grouping column from the results, it is redundant
 - [ ] Expand the tests to test multiple value key grouping sets
+- [ ] Force the Keys to be case-insensitive

--- a/src/KeyValue/Multi.php
+++ b/src/KeyValue/Multi.php
@@ -46,7 +46,7 @@ abstract class Multi extends \RyanWHowe\KeyValueStore\KeyValue {
      * Get the record associated with the specific key, value pair, the most recent series value
      *
      * @param $key
-     * @return array
+     * @return bool|array
      * @throws \Doctrine\DBAL\DBALException
      */
     public function get($key)

--- a/tests/KeyValue/DataTransaction.php
+++ b/tests/KeyValue/DataTransaction.php
@@ -38,6 +38,37 @@ abstract class DataTransaction extends TestCase {
     }
 
     /**
+     * This test provider is for ensuring consisten test
+     *
+     * @return array
+     */
+    public function groupingTestProvider()
+    {
+        return array(
+            /* input Name, expected Name, should match expected */
+            array('GroupName', 'GroupName', true),
+            array('GroupName1', 'GroupName1', true),
+            array('Group Name', 'Group_Name', true),
+            array('G r o u p N a m e ', 'G_r_o_u_p_N_a_m_e', true),
+            array(' GroupName', 'GroupName', true),
+            array(' GroupName ', 'GroupName', true),
+            array('GroupName 12', 'GroupName_12', true),
+            array(' G r o u p N a m e 1 2 ', 'G_r_o_u_p_N_a_m_e_1_2', true),
+            array('GroupName', 'GroupName', true),
+
+            array(' GroupName', ' GroupName', false),
+            array('GroupName1 ', 'GroupName1 ', false),
+            array('Group Name', 'Group Name', false),
+            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
+            array(' GroupName', ' GroupName', false),
+            array(' GroupName ', ' GroupName ', false),
+            array('GroupName 12', 'GroupName 12', false),
+            array(' G r o u p N a m e 1 2 ', ' G r o u p N a m e 1 2 ', false),
+            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
+        );
+    }
+
+    /**
      * This is the setUp method, this will create the testing database connected to a local SQLite instanced in
      * memory, there should be no residual tables or test data to clean up from this class.
      *

--- a/tests/KeyValue/DataTransaction.php
+++ b/tests/KeyValue/DataTransaction.php
@@ -103,6 +103,67 @@ abstract class DataTransaction extends TestCase {
     }
 
     /**
+     * This data set is intended to be ingested through the various setters and getters, therefor the expected
+     * output is not provided in this data, the expected output needs to be generated for the different testing
+     * conditions since setting through a Single vs Series vs DistinctSeries will have different outcomes.  This
+     * extends the setGetDataProvider in that multiple key value pares are tested as input and for the output.
+     *
+     * @return array
+     */
+    public function multiKeyDataProvider()
+    {
+        return array(
+            /* Test 1 */
+            array('test' => array(
+                array(
+                    'key'    => 'Key1',
+                    'values' => array('Value1')
+                ),
+
+                array(
+                    'key'    => 'Key2',
+                    'values' => array('Value1', 'Value2', 'Value3', 'Value2', 'Value1')
+                ),
+
+                array(
+                    'key'    => 'Key3',
+                    'values' => array('Value1', 'Value2', 'Value3', 'Value4', 'Value5')
+                ),
+
+                array(
+                    'key'    => 'Key4',
+                    'values' => array('Value4', 'Value4', 'Value4', 'Value4', 'Value4')
+                ),
+            )
+            ),
+            /* Test 2 */
+            array('test' => array(
+                array(
+                    'key'    => 'Key1',
+                    'values' => array('Value1')
+                ),
+
+                array(
+                    'key'    => 'Key2',
+                    'values' => array('Value1', 'Value2', 'Value3', 'Value2', 'Value1')
+                ),
+
+                array(
+                    'key'    => 'Key3',
+                    'values' => array('Value1', 'Value2', 'Value3', 'Value4', 'Value5')
+                ),
+
+                array(
+                    'key'    => 'Key4',
+                    'values' => array('Value4', 'Value4', 'Value4', 'Value4', 'Value4')
+                ),
+            )
+            )
+        );
+    }
+
+
+    /**
      * This is the setUp method, this will create the testing database connected to a local SQLite instanced in
      * memory, there should be no residual tables or test data to clean up from this class.
      *

--- a/tests/KeyValue/DataTransaction.php
+++ b/tests/KeyValue/DataTransaction.php
@@ -69,6 +69,40 @@ abstract class DataTransaction extends TestCase {
     }
 
     /**
+     * This data set is intended to be ingested through the various value setters and getters, therefor the expected
+     * output is not provided in this data, the expected output needs to be generated for the different testing
+     * conditions since setting through a Single vs Series vs DistinctSeries will have different outcomes
+     *
+     * @return array
+     */
+    public function setGetDataProvider()
+    {
+        return array(
+
+            array(
+                'key'    => 'Key1',
+                'values' => array('Value1')
+            ),
+
+            array(
+                'key'    => 'Key2',
+                'values' => array('Value1', 'Value2', 'Value3', 'Value2', 'Value1')
+            ),
+
+            array(
+                'key'    => 'Key3',
+                'values' => array('Value1', 'Value2', 'Value3', 'Value4', 'Value5')
+            ),
+
+            array(
+                'key'    => 'Key4',
+                'values' => array('Value4', 'Value4', 'Value4', 'Value4', 'Value4')
+            ),
+
+        );
+    }
+
+    /**
      * This is the setUp method, this will create the testing database connected to a local SQLite instanced in
      * memory, there should be no residual tables or test data to clean up from this class.
      *

--- a/tests/KeyValue/DistinctSeriesTest.php
+++ b/tests/KeyValue/DistinctSeriesTest.php
@@ -12,31 +12,6 @@ use RyanWHowe\KeyValueStore\KeyValue\DistinctSeries;
 
 class DistinctSeriesTest extends DataTransaction {
 
-    public function groupingTestProvider()
-    {
-        return array(
-            array('GroupName', 'GroupName', true),
-            array('GroupName1', 'GroupName1', true),
-            array('Group Name', 'Group_Name', true),
-            array('G r o u p N a m e ', 'G_r_o_u_p_N_a_m_e', true),
-            array(' GroupName', 'GroupName', true),
-            array(' GroupName ', 'GroupName', true),
-            array('GroupName 12', 'GroupName_12', true),
-            array(' G r o u p N a m e 1 2 ', 'G_r_o_u_p_N_a_m_e_1_2', true),
-            array('GroupName', 'GroupName', true),
-
-            array(' GroupName', ' GroupName', false),
-            array('GroupName1 ', 'GroupName1 ', false),
-            array('Group Name', 'Group Name', false),
-            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
-            array(' GroupName', ' GroupName', false),
-            array(' GroupName ', ' GroupName ', false),
-            array('GroupName 12', 'GroupName 12', false),
-            array(' G r o u p N a m e 1 2 ', ' G r o u p N a m e 1 2 ', false),
-            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
-        );
-    }
-
     /**
      * @test
      * @covers \RyanWHowe\KeyValueStore\Manager::__construct

--- a/tests/KeyValue/DistinctSeriesTest.php
+++ b/tests/KeyValue/DistinctSeriesTest.php
@@ -149,24 +149,19 @@ class DistinctSeriesTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue\DistinctSeries::update
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::get
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::getSeriesCreateDate
+     * @dataProvider setGetDataProvider
+     * @param string $key
+     * @param array $values
      * @throws \Exception
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function get()
+    public function get($key, $values)
     {
-        $testGrouping = 'DistinctSeriesValueSet';
-        $key = 'key1';
+        $testGrouping = 'DistinctSeriesValueGet';
         $expected_value = '';
         $value = array();
         $distinctSeriesValue = DistinctSeries::create($testGrouping, self::$connection);
-        $testSet = array(
-            'value1',
-            'value2',
-            'value3',
-            'value2',
-            'value1',
-        );
-        foreach ($testSet as $item) {
+        foreach ($values as $item) {
             $distinctSeriesValue->set($key, $item);
             if(!array_key_exists($item,$value)){
                 /* the last set distinct value needs to be captured */
@@ -284,24 +279,19 @@ class DistinctSeriesTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue\DistinctSeries::update
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::get
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::getSeriesCreateDate
+     * @dataProvider setGetDataProvider
+     * @param string $key
+     * @param array $values
      * @throws \Exception
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function set()
+    public function set($key, $values)
     {
         $testGrouping = 'DistinctSeriesValueSet';
-        $key = 'key1';
         $expected_value = '';
         $value = array();
         $distinctSeriesValue = DistinctSeries::create($testGrouping, self::$connection);
-        $testSet = array(
-            'value1',
-            'value2',
-            'value3',
-            'value2',
-            'value1',
-        );
-        foreach ($testSet as $item) {
+        foreach ($values as $item) {
             $distinctSeriesValue->set($key, $item);
             if(!array_key_exists($item,$value)){
                 /* the last set distinct value needs to be captured */
@@ -312,7 +302,7 @@ class DistinctSeriesTest extends DataTransaction {
         unset($result['last_update']);
         unset($result['value_created']);
         foreach ($value as $set_value=>$item) {
-                $expected_value = $set_value;
+            $expected_value = $set_value;
         }
 
         $this->assertEquals(array('grouping' => $testGrouping, 'key' => $key, 'value' => $expected_value), $result);

--- a/tests/KeyValue/SeriesTest.php
+++ b/tests/KeyValue/SeriesTest.php
@@ -26,23 +26,17 @@ class SeriesTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::get
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::getSeriesCreateDate
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Series::set
+     * @dataProvider setGetDataProvider
+     * @param string $key
+     * @param array $values
      * @throws \Exception
      */
-    public function set()
+    public function set($key, $values)
     {
-        $testGrouping = 'SeriesValueSet';
-        $key = 'key1';
+        $testGrouping = 'SeriesValueGet';
         $value = '';
         $seriesValue = Series::create($testGrouping, self::$connection);
-        $testSet = array(
-            'value1',
-            'value2',
-            'value3',
-            'value3',
-            'value1',
-            'anotherValue'
-        );
-        foreach ($testSet as $item) {
+        foreach ($values as $item) {
             $seriesValue->set($key, $item);
             $value = $item; //the expected output is the last value that was set in the series
         }
@@ -225,24 +219,18 @@ class SeriesTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::get
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Multi::getSeriesCreateDate
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Series::set
+     * @dataProvider setGetDataProvider
+     * @param string $key
+     * @param array $values
      * @throws \Doctrine\DBAL\DBALException
      * @throws \Exception
      */
-    public function get()
+    public function get($key, $values)
     {
         $testGrouping = 'SeriesValueGet';
-        $key = 'key1';
         $value = '';
         $seriesValue = Series::create($testGrouping, self::$connection);
-        $testSet = array(
-            'value1',
-            'value2',
-            'value3',
-            'value4',
-            'value5',
-            'otherValue'
-        );
-        foreach ($testSet as $item) {
+        foreach ($values as $item) {
             $seriesValue->set($key, $item);
             $value = $item; //the expected output is the last value that was set in the series
         }

--- a/tests/KeyValue/SeriesTest.php
+++ b/tests/KeyValue/SeriesTest.php
@@ -252,31 +252,6 @@ class SeriesTest extends DataTransaction {
         $this->assertEquals(array('grouping' => $testGrouping, 'key' => $key, 'value' => $value), $result);
     }
 
-    public function groupingTestProvider()
-    {
-        return array(
-            array('GroupName', 'GroupName', true),
-            array('GroupName1', 'GroupName1', true),
-            array('Group Name', 'Group_Name', true),
-            array('G r o u p N a m e ', 'G_r_o_u_p_N_a_m_e', true),
-            array(' GroupName', 'GroupName', true),
-            array(' GroupName ', 'GroupName', true),
-            array('GroupName 12', 'GroupName_12', true),
-            array(' G r o u p N a m e 1 2 ', 'G_r_o_u_p_N_a_m_e_1_2', true),
-            array('GroupName', 'GroupName', true),
-
-            array(' GroupName', ' GroupName', false),
-            array('GroupName1 ', 'GroupName1 ', false),
-            array('Group Name', 'Group Name', false),
-            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
-            array(' GroupName', ' GroupName', false),
-            array(' GroupName ', ' GroupName ', false),
-            array('GroupName 12', 'GroupName 12', false),
-            array(' G r o u p N a m e 1 2 ', ' G r o u p N a m e 1 2 ', false),
-            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
-        );
-    }
-
     /**
      * @test
      * @covers \RyanWHowe\KeyValueStore\Manager::__construct

--- a/tests/KeyValue/SingleTest.php
+++ b/tests/KeyValue/SingleTest.php
@@ -27,24 +27,25 @@ class SingleTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\Manager::create
      * @covers \RyanWHowe\KeyValueStore\Manager::createTable
      * @covers \RyanWHowe\KeyValueStore\Manager::dropTable
+     * @dataProvider multiKeyDataProvider
+     * @param array $testSet
      * @throws \Doctrine\DBAL\DBALException
      * @throws \Exception
      */
-    public function getAllKeys()
+    public function getAllKeys(array $testSet)
     {
-        $test = Single::create('SingleValueGetAllKeys', self::$connection);
-        $test->set('key1', 'value1');
-        $test->set('key1', 'value2');
-        $test->set('key2', 'value2');
-        $test->set('key2', 'value3');
-        $test->set('key3', 'value3');
-        $test->set('key3', 'value4');
-        $test->set('key4', 'value4');
-        $test->set('key4', 'value5');
-        $test->set('key5', 'value5');
-        $test->set('key5', 'value6');
-        $expected = array('key1', 'key2', 'key3', 'key4', 'key5');
-        $result = $test->getAllKeys();
+        $single = Single::create('SingleValueGetAllKeys', self::$connection);
+        $expected = array();
+        foreach ($testSet as $test) {
+            $key = $test['key'];
+            foreach ($test['values'] as $value) {
+                $single->set($key, $value);
+            }
+            $expected[] = $key;
+            $result = $single->getAllKeys();
+            $this->assertEquals($expected, $result);
+        }
+        $result = $single->getAllKeys();
         $this->assertEquals($expected, $result);
     }
 
@@ -62,25 +63,24 @@ class SingleTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue::getId
      * @covers \RyanWHowe\KeyValueStore\KeyValue::insert
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::set
+     * @dataProvider multiKeyDataProvider
+     * @param array $testSet
      * @throws \Doctrine\DBAL\DBALException
      * @throws \Exception
      */
-    public function getGroupingSet()
+    public function getGroupingSet($testSet)
     {
         $testGroup = 'SingleValueGetGroupingSet';
-
-        $expected = array(
-            array('grouping' => $testGroup, 'key' => 'key1', 'value' => 'value1'),
-            array('grouping' => $testGroup, 'key' => 'key2', 'value' => 'value2'),
-            array('grouping' => $testGroup, 'key' => 'key3', 'value' => 'value3'),
-            array('grouping' => $testGroup, 'key' => 'key4', 'value' => 'value4'),
-            array('grouping' => $testGroup, 'key' => 'key5', 'value' => 'value5'),
-            array('grouping' => $testGroup, 'key' => 'key6', 'value' => 'value6')
-        );
-
         $singleValue = Single::create($testGroup, self::$connection);
-        foreach ($expected as $item) {
-            $singleValue->set($item['key'], $item['value']);
+        $expected = array();
+        $expected_value = '';
+        foreach ($testSet as $test) {
+            $key = $test['key'];
+            foreach ($test['values'] as $value) {
+                $singleValue->set($key, $value);
+                $expected_value = $value; // we expect the last value set
+            }
+            $expected[] = array('grouping' => $testGroup, 'key' => $key, 'value' => $expected_value);
         }
 
         $result = $singleValue->getGroupingSet();

--- a/tests/KeyValue/SingleTest.php
+++ b/tests/KeyValue/SingleTest.php
@@ -168,34 +168,6 @@ class SingleTest extends DataTransaction {
     }
 
     /**
-     * @return array
-     */
-    public function groupingTestProvider()
-    {
-        return array(
-            array('GroupName', 'GroupName', true),
-            array('GroupName1', 'GroupName1', true),
-            array('Group Name', 'Group_Name', true),
-            array('G r o u p N a m e ', 'G_r_o_u_p_N_a_m_e', true),
-            array(' GroupName', 'GroupName', true),
-            array(' GroupName ', 'GroupName', true),
-            array('GroupName 12', 'GroupName_12', true),
-            array(' G r o u p N a m e 1 2 ', 'G_r_o_u_p_N_a_m_e_1_2', true),
-            array('GroupName', 'GroupName', true),
-
-            array(' GroupName', ' GroupName', false),
-            array('GroupName1 ', 'GroupName1 ', false),
-            array('Group Name', 'Group Name', false),
-            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
-            array(' GroupName', ' GroupName', false),
-            array(' GroupName ', ' GroupName ', false),
-            array('GroupName 12', 'GroupName 12', false),
-            array(' G r o u p N a m e 1 2 ', ' G r o u p N a m e 1 2 ', false),
-            array('G r o u p N a m e ', 'G r o u p N a m e ', false),
-        );
-    }
-
-    /**
      * @test
      * @covers \RyanWHowe\KeyValueStore\Manager::__construct
      * @covers \RyanWHowe\KeyValueStore\Manager::create

--- a/tests/KeyValue/SingleTest.php
+++ b/tests/KeyValue/SingleTest.php
@@ -138,26 +138,18 @@ class SingleTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::get
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::set
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::update
+     * @dataProvider setGetDataProvider
+     * @param string $key
+     * @param array $values
      * @throws \Exception
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function set()
+    public function set($key, array $values)
     {
         $testGroup = 'SingleValueSet';
-        $key = 'Key1';
         $expected = '';
-        $testValues = array(
-            'value1',
-            'value2',
-            'value3',
-            'value4',
-            'value5',
-            'value6',
-            'value3'
-        );
-
         $singleValue = Single::create($testGroup, self::$connection);
-        foreach ($testValues as $value) {
+        foreach ($values as $value) {
             $singleValue->set($key, $value);
             $expected = $value;  // the last set value is what we expect out
         }
@@ -206,26 +198,18 @@ class SingleTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::get
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::set
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::update
+     * @dataProvider setGetDataProvider
+     * @param string $key
+     * @param array $values
      * @throws \Doctrine\DBAL\DBALException
      * @throws \Exception
      */
-    public function get()
+    public function get($key, array $values)
     {
         $testGroup = 'SingleValueGet';
-        $key = 'Key1';
         $expected = '';
-        $testValues = array(
-            'value1',
-            'value2',
-            'value3',
-            'value4',
-            'value5',
-            'value6',
-            'value3'
-        );
-
         $singleValue = Single::create($testGroup, self::$connection);
-        foreach ($testValues as $value) {
+        foreach ($values as $value) {
             $singleValue->set($key, $value);
             $expected = $value;  // the last set value is what we expect out
         }


### PR DESCRIPTION
Added two new data providers to the DataTransaction abstract base test
- setGetDataProvider - used to test all set and get methods for data classes
- multiKeyDataProvider - used to test all getAll & getSet methods