### PR TITLE
Removed grouping outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ This extends the key/value store in several ways
 Keys are forced to be case-insensitive
 
 #### To Do (1.0)
-- [ ] Remove the grouping column from the results, it is redundant
-- [ ] Expand the tests to test multiple value key grouping sets
-- [ ] Force the Keys to be case-insensitive
+- [x] Remove the grouping column from the results, it is redundant
+- [x] Expand the tests to test multiple value key grouping sets
+- [x] Force the Keys to be case-insensitive

--- a/src/KeyValue/Multi.php
+++ b/src/KeyValue/Multi.php
@@ -54,7 +54,6 @@ abstract class Multi extends \RyanWHowe\KeyValueStore\KeyValue {
         {
             $sql = "
             SELECT
-                `grouping`,
                 `key`,
                 `value`,
                 `last_update`
@@ -88,7 +87,6 @@ abstract class Multi extends \RyanWHowe\KeyValueStore\KeyValue {
     {
         $sql = "
             SELECT
-                `grouping`,
                 `key`,
                 `value`,
                 `last_update`,

--- a/src/KeyValue/Single.php
+++ b/src/KeyValue/Single.php
@@ -59,7 +59,7 @@ class Single extends \RyanWHowe\KeyValueStore\KeyValue {
      * Query the database for a single value from a grouping
      *
      * @param $key
-     * @return array
+     * @return bool|array
      * @throws \Doctrine\DBAL\DBALException
      */
     public function get($key)

--- a/tests/KeyValue/DistinctSeriesTest.php
+++ b/tests/KeyValue/DistinctSeriesTest.php
@@ -162,7 +162,7 @@ class DistinctSeriesTest extends DataTransaction {
             $expected_value = $set_value;
         }
 
-        $this->assertEquals(array('grouping' => $testGrouping, 'key' => \strtolower($key), 'value' => $expected_value), $result);
+        $this->assertEquals(array('key' => \strtolower($key), 'value' => $expected_value), $result);
     }
 
     /**
@@ -202,7 +202,7 @@ class DistinctSeriesTest extends DataTransaction {
                 }
             }
             foreach ($expected_values as $values => $item) {
-                $expected[] = array('grouping' => $testGrouping, 'key' => \strtolower($key), 'value' => $values);
+                $expected[] = array('key' => \strtolower($key), 'value' => $values);
             }
             $result = $distinctSeries->getSet($key);
             // unset the timestamps, which will vary with time
@@ -229,6 +229,7 @@ class DistinctSeriesTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue::getId
      * @covers \RyanWHowe\KeyValueStore\KeyValue::insert
      * @covers \RyanWHowe\KeyValueStore\KeyValue\DistinctSeries::set
+     * @covers \RyanWHowe\KeyValueStore\KeyValue\DistinctSeries::update
      * @dataProvider multiKeyDataProvider
      * @param array $testSet
      * @throws \Exception
@@ -294,7 +295,7 @@ class DistinctSeriesTest extends DataTransaction {
             $expected_value = $set_value;
         }
 
-        $this->assertEquals(array('grouping' => $testGrouping, 'key' => \strtolower($key), 'value' => $expected_value), $result);
+        $this->assertEquals(array('key' => \strtolower($key), 'value' => $expected_value), $result);
     }
 
     /**

--- a/tests/KeyValue/SeriesTest.php
+++ b/tests/KeyValue/SeriesTest.php
@@ -43,7 +43,7 @@ class SeriesTest extends DataTransaction {
         $result = $seriesValue->get($key);
         unset($result['last_update']);
         unset($result['value_created']);
-        $this->assertEquals(array('grouping' => $testGrouping, 'key' => \strtolower($key), 'value' => $value), $result);
+        $this->assertEquals(array('key' => \strtolower($key), 'value' => $value), $result);
     }
 
     /**
@@ -74,7 +74,7 @@ class SeriesTest extends DataTransaction {
             $key = $item['key'];
             foreach ($item['values'] as $value) {
                 $seriesValue->set($key, $value);
-                $expected[] = array('grouping' => $testGrouping, 'key' => \strtolower($key), 'value' => $value);
+                $expected[] = array('key' => \strtolower($key), 'value' => $value);
             }
 
             $result = $seriesValue->getSet($key);
@@ -217,7 +217,7 @@ class SeriesTest extends DataTransaction {
         $result = $seriesValue->get($key);
         unset($result['last_update']);
         unset($result['value_created']);
-        $this->assertEquals(array('grouping' => $testGrouping, 'key' => \strtolower($key), 'value' => $value), $result);
+        $this->assertEquals(array('key' => \strtolower($key), 'value' => $value), $result);
     }
 
     /**

--- a/tests/KeyValue/SingleTest.php
+++ b/tests/KeyValue/SingleTest.php
@@ -63,6 +63,7 @@ class SingleTest extends DataTransaction {
      * @covers \RyanWHowe\KeyValueStore\KeyValue::getId
      * @covers \RyanWHowe\KeyValueStore\KeyValue::insert
      * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::set
+     * @covers \RyanWHowe\KeyValueStore\KeyValue\Single::update
      * @dataProvider multiKeyDataProvider
      * @param array $testSet
      * @throws \Doctrine\DBAL\DBALException
@@ -250,6 +251,19 @@ class SingleTest extends DataTransaction {
 
     /**
      * @test
+     * @covers       \RyanWHowe\KeyValueStore\Manager::__construct
+     * @covers       \RyanWHowe\KeyValueStore\Manager::create
+     * @covers       \RyanWHowe\KeyValueStore\Manager::createTable
+     * @covers       \RyanWHowe\KeyValueStore\Manager::dropTable
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::__construct
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::create
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::formatGrouping
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::getAllKeys
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::getGrouping
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::getId
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue::insert
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue\Single::set
+     * @covers       \RyanWHowe\KeyValueStore\KeyValue\Single::update
      * @dataProvider nonUniqueKeyDataProvider
      * @throws \Exception
      */


### PR DESCRIPTION
- Removed the Grouping output in the return arrays for all set baised outputs
- Updated tests to match new output format